### PR TITLE
Feat: Integrate VirtualTourSection with Sanity CMS

### DIFF
--- a/client/src/components/sections/VirtualTourSection.tsx
+++ b/client/src/components/sections/VirtualTourSection.tsx
@@ -1,41 +1,66 @@
-import { useState } from "react";
+import { useState, CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
-import { Play } from "lucide-react";
+import { Play, Loader2 } from "lucide-react";
 import VirtualTour from "@/components/ui/virtual-tour";
 import { motion } from "framer-motion";
+import { useVirtualTourSection } from "@/hooks/useSanity";
+import { urlFor } from "@/lib/sanity";
 
-const tourHotspots = [
-  {
-    id: "area-iniciantes",
-    label: "1",
-    position: { top: "25%", left: "25%" },
-    title: "Área de Iniciantes"
-  },
-  {
-    id: "area-avancada",
-    label: "2",
-    position: { top: "33%", right: "33%" },
-    title: "Área Avançada"
-  },
-  {
-    id: "area-treinamento",
-    label: "3",
-    position: { bottom: "25%", right: "25%" },
-    title: "Área de Treinamento"
-  }
-];
+interface HotspotPosition {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+}
 
-const tourAreas = [
-  "Área de Iniciantes",
-  "Área Avançada",
-  "Área de Treinamento",
-  "Vestiários",
-  "Cafeteria"
-];
+interface TourHotspot {
+  _key: string;
+  id?: string;
+  label?: string;
+  title?: string;
+  position?: HotspotPosition;
+}
 
 const VirtualTourSection = () => {
   const [activeArea, setActiveArea] = useState<string | null>(null);
   const [showTour, setShowTour] = useState(false);
+  const { data: virtualTourData, isLoading, error } = useVirtualTourSection();
+
+  if (isLoading) {
+    return (
+      <section className="py-16 bg-neutral-900 text-white">
+        <div className="container mx-auto px-4 text-center">
+          <Loader2 className="h-12 w-12 animate-spin text-primary mx-auto" />
+          <p className="mt-4">Carregando Tour Virtual...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error || !virtualTourData) {
+    return (
+      <section className="py-16 bg-neutral-900 text-white">
+        <div className="container mx-auto px-4 text-center text-red-400">
+          <p>Ocorreu um erro ao carregar o Tour Virtual.</p>
+          <p>Tente novamente mais tarde.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const { title, description, fallbackImage, tourHotspots, tourAreas, videoUrl } = virtualTourData;
+
+  // Helper to convert Sanity position to CSS style
+  const getHotspotStyle = (position?: HotspotPosition): CSSProperties => {
+    const style: CSSProperties = {};
+    if (position?.top !== undefined) style.top = `${position.top}%`;
+    if (position?.right !== undefined) style.right = `${position.right}%`;
+    if (position?.bottom !== undefined) style.bottom = `${position.bottom}%`;
+    if (position?.left !== undefined) style.left = `${position.left}%`;
+    return style;
+  };
+
+  const fallbackImageUrl = fallbackImage ? urlFor(fallbackImage).url() : "https://pixabay.com/get/gcb0e054558248cdbe579eb1b477fab688439e561847153139cf077f78486c1069c59479e94da76c919029fe0c6d7ca9906078cb5a03cec3113b82e7d5c973192_1280.jpg";
 
   return (
     <section className="py-16 bg-neutral-900 text-white">
@@ -47,10 +72,12 @@ const VirtualTourSection = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
         >
-          <h2 className="text-3xl font-bold mb-4 font-sans">Tour Virtual 360°</h2>
-          <p className="text-neutral-300 max-w-2xl mx-auto">
-            Explore nossa estrutura completa em uma experiência interativa 360°.
-          </p>
+          <h2 className="text-3xl font-bold mb-4 font-sans">{title || 'Tour Virtual 360°'}</h2>
+          {description && (
+            <p className="text-neutral-300 max-w-2xl mx-auto">
+              {description}
+            </p>
+          )}
         </motion.div>
 
         <motion.div 
@@ -61,69 +88,72 @@ const VirtualTourSection = () => {
           transition={{ duration: 0.8 }}
         >
           {showTour ? (
-            <VirtualTour activeArea={activeArea} />
+            <VirtualTour activeArea={activeArea} videoUrl={videoUrl} />
           ) : (
             <>
               <img 
-                src="https://pixabay.com/get/gcb0e054558248cdbe579eb1b477fab688439e561847153139cf077f78486c1069c59479e94da76c919029fe0c6d7ca9906078cb5a03cec3113b82e7d5c973192_1280.jpg" 
+                src={fallbackImageUrl}
                 alt="Interior do Centro de Boulder" 
                 className="w-full h-full object-cover"
+                loading="lazy"
               />
               
-              {/* Tour Overlay */}
               <div className="absolute inset-0 bg-gradient-to-b from-transparent to-neutral-900/60 flex items-center justify-center">
                 <Button 
                   size="lg"
                   className="bg-primary hover:bg-primary/90 text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg transition duration-300 transform hover:scale-110"
                   onClick={() => setShowTour(true)}
+                  aria-label="Iniciar Tour Virtual"
                 >
                   <Play className="h-6 w-6" />
                 </Button>
               </div>
               
-              {/* Tour Hotspots */}
-              {tourHotspots.map((spot) => (
-                <div 
-                  key={spot.id}
-                  className="tour-hotspot absolute w-8 h-8 bg-primary/80 rounded-full flex items-center justify-center cursor-pointer"
-                  style={{ ...spot.position }}
+              {tourHotspots && tourHotspots.map((spot: TourHotspot) => (
+                <button
+                  key={spot._key || spot.id}
+                  className="tour-hotspot absolute w-8 h-8 bg-primary/80 rounded-full flex items-center justify-center cursor-pointer hover:bg-primary transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-neutral-900"
+                  style={getHotspotStyle(spot.position)}
                   onClick={() => {
-                    setActiveArea(spot.title);
+                    if (spot.title) setActiveArea(spot.title);
                     setShowTour(true);
                   }}
+                  aria-label={`Ir para ${spot.title || 'área do tour'}`}
                 >
-                  <span className="text-white text-xs font-bold">{spot.label}</span>
-                </div>
+                  <span className="text-white text-xs font-bold">{spot.label || '?'}</span>
+                </button>
               ))}
             </>
           )}
         </motion.div>
 
-        <motion.div 
-          className="mt-6 max-w-5xl mx-auto"
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-        >
-          <div className="flex flex-wrap justify-center gap-2">
-            {tourAreas.map((area) => (
-              <Button
-                key={area}
-                variant="outline"
-                className={`px-4 py-2 ${activeArea === area 
-                  ? 'bg-primary/90 hover:bg-primary text-white' 
-                  : 'bg-white/10 hover:bg-white/20'} rounded-md text-sm transition duration-300`}
-                onClick={() => {
-                  setActiveArea(area);
-                  setShowTour(true);
-                }}
-              >
-                {area}
-              </Button>
-            ))}
-          </div>
-        </motion.div>
+        {tourAreas && tourAreas.length > 0 && (
+          <motion.div
+            className="mt-6 max-w-5xl mx-auto"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+          >
+            <div className="flex flex-wrap justify-center gap-2">
+              {tourAreas.map((area: string) => (
+                <Button
+                  key={area}
+                  variant="outline"
+                  className={`px-4 py-2 ${activeArea === area && showTour
+                    ? 'bg-primary hover:bg-primary/90 text-white'
+                    : 'bg-white/10 hover:bg-white/20 text-neutral-300 hover:text-white'} rounded-md text-sm transition duration-300`}
+                  onClick={() => {
+                    setActiveArea(area);
+                    setShowTour(true);
+                  }}
+                >
+                  {area}
+                </Button>
+              ))}
+            </div>
+          </motion.div>
+        )}
       </div>
     </section>
   );

--- a/client/src/hooks/useSanity.ts
+++ b/client/src/hooks/useSanity.ts
@@ -17,6 +17,14 @@ export function useHeroSection() {
   })
 }
 
+export function useVirtualTourSection() {
+  return useQuery({
+    queryKey: ['sanity', 'virtualTourSection'],
+    queryFn: () => client.fetch(queries.virtualTourSection),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
 export function usePrograms() {
   return useQuery({
     queryKey: ['sanity', 'programs'],

--- a/client/src/lib/sanity.ts
+++ b/client/src/lib/sanity.ts
@@ -184,5 +184,20 @@ export const queries = {
       timeSlots
     },
     notes
+  }`,
+
+  virtualTourSection: `*[_type == "virtualTourSection"][0]{
+    title,
+    description,
+    fallbackImage,
+    tourHotspots[]{
+      _key,
+      id,
+      label,
+      title,
+      position
+    },
+    tourAreas[],
+    videoUrl
   }`
 }

--- a/sanity/studio/schemas/index.ts
+++ b/sanity/studio/schemas/index.ts
@@ -8,6 +8,7 @@ import communitySection from './communitySection'
 import faqSection from './faqSection'
 import contactSection from './contactSection'
 import schedulingSection from './schedulingSection'
+import virtualTourSection from './virtualTourSection'
 
 export const schemaTypes = [
   siteSettings,
@@ -19,5 +20,6 @@ export const schemaTypes = [
   communitySection,
   faqSection,
   contactSection,
-  schedulingSection
+  schedulingSection,
+  virtualTourSection
 ]

--- a/sanity/studio/schemas/virtualTourSection.ts
+++ b/sanity/studio/schemas/virtualTourSection.ts
@@ -1,0 +1,89 @@
+export default {
+  name: 'virtualTourSection',
+  title: 'Seção Tour Virtual',
+  type: 'document',
+  __experimental_actions: ['update', 'publish'],
+  fields: [
+    {
+      name: 'title',
+      title: 'Título',
+      type: 'string',
+      validation: (Rule: any) => Rule.required()
+    },
+    {
+      name: 'description',
+      title: 'Descrição',
+      type: 'text'
+    },
+    {
+      name: 'fallbackImage',
+      title: 'Imagem de Fallback',
+      type: 'image',
+      options: {
+        hotspot: true
+      },
+      description: 'Imagem exibida antes do tour carregar ou caso haja erro.'
+    },
+    {
+      name: 'tourHotspots',
+      title: 'Hotspots do Tour',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'id',
+              title: 'ID',
+              type: 'string',
+              description: 'Identificador único para o hotspot (ex: area-iniciantes)'
+            },
+            {
+              name: 'label',
+              title: 'Rótulo',
+              type: 'string',
+              description: 'Texto exibido no hotspot (ex: "1", "A")'
+            },
+            {
+              name: 'title',
+              title: 'Título do Hotspot',
+              type: 'string',
+              description: 'Nome da área que o hotspot representa'
+            },
+            {
+              name: 'position',
+              title: 'Posição',
+              type: 'object',
+              fields: [
+                { name: 'top', title: 'Topo (%)', type: 'number' },
+                { name: 'right', title: 'Direita (%)', type: 'number' },
+                { name: 'bottom', title: 'Abaixo (%)', type: 'number' },
+                { name: 'left', title: 'Esquerda (%)', type: 'number' }
+              ],
+              description: 'Posicionamento percentual do hotspot na imagem de fallback.'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'tourAreas',
+      title: 'Áreas do Tour',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Nomes das diferentes áreas navegáveis no tour virtual (ex: "Área de Iniciantes", "Vestiários").'
+    },
+    {
+      name: 'videoUrl',
+      title: 'URL do Vídeo do Tour',
+      type: 'url',
+      description: 'URL do vídeo 360 graus (opcional, se estiver usando um player de vídeo externo).'
+    }
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'description'
+    }
+  }
+}


### PR DESCRIPTION
- Created a new Sanity schema 'virtualTourSection' to manage content for the virtual tour.
- Updated the 'VirtualTourSection' React component to fetch and display data from Sanity, including title, description, fallback image, interactive hotspots, and navigation areas.
- Added the new schema to the Sanity Studio configuration, making it available for content editors.
- Included necessary Sanity client queries and React Query hooks for data fetching.

