### PR TITLE
Centralize Contact Info in Sanity CMS

### DIFF
--- a/DOCUMENTATION_UPDATE_CONTACT.md
+++ b/DOCUMENTATION_UPDATE_CONTACT.md
@@ -1,0 +1,37 @@
+# Como Atualizar as Informações de Contato
+
+Este documento descreve como atualizar o endereço, telefone, e-mail e horário de funcionamento da Academia Boulder.
+
+A partir de agora, todas essas informações são gerenciadas em um único lugar: **Configurações Gerais** (Site Settings) no painel do Sanity (CMS). As alterações feitas lá refletirão automaticamente tanto no rodapé (Footer) quanto na seção de contato.
+
+## Passo a Passo
+
+1.  **Acesse o Sanity Studio**.
+    *   Geralmente acessível através da URL `/studio` ou onde o CMS estiver hospedado.
+
+2.  **Navegue até "Configurações Gerais"**.
+    *   No menu lateral esquerdo, clique em "⚙️ Configurações Gerais".
+
+3.  **Atualize as Informações de Contato**.
+    *   Role até a seção "Informações de Contato".
+    *   **Endereço**: Digite o novo endereço completo.
+    *   **Telefone**: Digite o novo número de telefone.
+        *   Recomendado incluir o código do país e DDD, ex: `+55 15 99186-9689`.
+        *   Este número será usado automaticamente para o link do WhatsApp (o sistema remove caracteres não numéricos e adiciona o código 55 se necessário).
+    *   **Email**: Digite o novo e-mail de contato.
+    *   **Horário de Funcionamento**: Digite os horários.
+        *   Você pode usar múltiplas linhas para separar os dias.
+        *   Exemplo:
+            ```
+            Seg-Sex: 06h às 11h
+            Sáb: 09h às 13h
+            ```
+
+4.  **Publique as Alterações**.
+    *   Clique no botão "Publish" (Publicar) no canto inferior direito (ou superior direito, dependendo da versão) para salvar.
+
+## Notas Importantes
+
+*   **Fonte Única de Dados**: A seção de contato do site (`ContactSection`) agora ignora os dados inseridos especificamente no documento "Seção Contato" para estes campos (endereço, telefone, email, horário) e usa exclusivamente os dados de "Configurações Gerais". Isso garante que a informação esteja sempre sincronizada em todo o site.
+*   **WhatsApp**: O botão de "Enviar Mensagem" e o ícone do WhatsApp usam o número de telefone definido em "Configurações Gerais".
+*   **Mapas**: O mapa exibido na seção de contato é gerenciado separadamente (através do código embed) e não é atualizado automaticamente ao mudar o texto do endereço. Caso o endereço mude drasticamente, um desenvolvedor precisará atualizar o embed do mapa.

--- a/client/src/__tests__/ContactSection.test.tsx
+++ b/client/src/__tests__/ContactSection.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import ContactSection from '@/components/sections/ContactSection';
+import { useSiteSettings } from '@/hooks/useSanity';
+import { vi, describe, it, expect } from 'vitest';
+
+// Mock the hook
+vi.mock('@/hooks/useSanity', () => ({
+  useSiteSettings: vi.fn(),
+}));
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('ContactSection', () => {
+  it('renders fallback contact info when data is missing', () => {
+    // Mock return value for no data
+    (useSiteSettings as any).mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+
+    render(<ContactSection />);
+
+    // Check for fallback hardcoded values
+    expect(screen.getByText('Avenida Getúlio Vargas, 475 - Jardim São Paulo, Sorocaba - SP')).toBeInTheDocument();
+    expect(screen.getByText('+55 15 99186-9689')).toBeInTheDocument();
+    expect(screen.getByText('academiaboulder@gmail.com')).toBeInTheDocument();
+    expect(screen.getByText('Seg-Sex: 06h às 11h')).toBeInTheDocument();
+  });
+
+  it('renders dynamic contact info when data is present', () => {
+    const mockData = {
+      contactInfo: {
+        address: 'Nova Rua, 123',
+        phone: '+55 11 99999-9999',
+        email: 'novo@email.com',
+        hours: 'Seg-Dom: 24h',
+      },
+    };
+
+    (useSiteSettings as any).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+    });
+
+    render(<ContactSection />);
+
+    expect(screen.getByText('Nova Rua, 123')).toBeInTheDocument();
+    expect(screen.getByText('+55 11 99999-9999')).toBeInTheDocument();
+    expect(screen.getByText('novo@email.com')).toBeInTheDocument();
+    expect(screen.getByText('Seg-Dom: 24h')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -147,7 +147,7 @@ const Footer = () => {
               {contactInfo.hours && (
                 <li className="flex items-start">
                   <Clock className="h-5 w-5 mt-1 mr-2 flex-shrink-0" />
-                  <span className="text-neutral-300">{contactInfo.hours}</span>
+                  <span className="text-neutral-300 whitespace-pre-line">{contactInfo.hours}</span>
                 </li>
               )}
             </ul>

--- a/client/src/components/sections/ContactSection.tsx
+++ b/client/src/components/sections/ContactSection.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Checkbox } from "@/components/ui/checkbox";
 import { MapPin, Phone, Mail, Clock, Facebook, Instagram, Youtube } from "lucide-react";
 import { motion } from "framer-motion";
+import { useSiteSettings } from "@/hooks/useSanity";
 
 const contactFormSchema = z.object({
   name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
@@ -28,6 +29,7 @@ const WHATSAPP_NUMBER = "5515991869689";
 
 const ContactSection = () => {
   const { toast } = useToast();
+  const { data: siteSettings } = useSiteSettings();
   
   const form = useForm<ContactFormValues>({
     resolver: zodResolver(contactFormSchema),
@@ -40,10 +42,19 @@ const ContactSection = () => {
     },
   });
 
+  const getWhatsappNumber = () => {
+    let phone = siteSettings?.contactInfo?.phone || WHATSAPP_NUMBER;
+    phone = phone.replace(/\D/g, "");
+    if (phone.length >= 10 && phone.length <= 11) {
+      phone = "55" + phone;
+    }
+    return phone;
+  };
+
   function onSubmit(data: ContactFormValues) {
     const text = `*Nova mensagem do site*\n\n*Nome:* ${data.name}\n*Email:* ${data.email}\n*Assunto:* ${data.subject}\n*Mensagem:* ${data.message}`;
     const encodedText = encodeURIComponent(text);
-    const whatsappUrl = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodedText}`;
+    const whatsappUrl = `https://wa.me/${getWhatsappNumber()}?text=${encodedText}`;
 
     window.open(whatsappUrl, '_blank');
 
@@ -211,7 +222,7 @@ const ContactSection = () => {
                   </div>
                   <div>
                     <h4 className="font-medium">Endereço</h4>
-                    <p className="text-neutral-300">Avenida Getúlio Vargas, 475 - Jardim São Paulo, Sorocaba - SP</p>
+                    <p className="text-neutral-300">{siteSettings?.contactInfo?.address || "Avenida Getúlio Vargas, 475 - Jardim São Paulo, Sorocaba - SP"}</p>
                   </div>
                 </div>
                 
@@ -221,7 +232,7 @@ const ContactSection = () => {
                   </div>
                   <div>
                     <h4 className="font-medium">Telefone</h4>
-                    <p className="text-neutral-300">+55 15 99186-9689</p>
+                    <p className="text-neutral-300">{siteSettings?.contactInfo?.phone || "+55 15 99186-9689"}</p>
                   </div>
                 </div>
                 
@@ -231,7 +242,7 @@ const ContactSection = () => {
                   </div>
                   <div>
                     <h4 className="font-medium">E-mail</h4>
-                    <p className="text-neutral-300">academiaboulder@gmail.com</p>
+                    <p className="text-neutral-300">{siteSettings?.contactInfo?.email || "academiaboulder@gmail.com"}</p>
                   </div>
                 </div>
                 
@@ -241,8 +252,14 @@ const ContactSection = () => {
                   </div>
                   <div>
                     <h4 className="font-medium">Horário de Funcionamento</h4>
-                    <p className="text-neutral-300">Seg-Sex: 06h às 11h</p>
-                    <p className="text-neutral-300">Sáb: 09h às 13h</p>
+                    {siteSettings?.contactInfo?.hours ? (
+                      <p className="text-neutral-300 whitespace-pre-line">{siteSettings.contactInfo.hours}</p>
+                    ) : (
+                      <>
+                        <p className="text-neutral-300">Seg-Sex: 06h às 11h</p>
+                        <p className="text-neutral-300">Sáb: 09h às 13h</p>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
@@ -280,7 +297,7 @@ const ContactSection = () => {
                   <Youtube className="h-5 w-5" />
                 </a>
                 <a 
-                  href={`https://wa.me/${WHATSAPP_NUMBER}`}
+                  href={`https://wa.me/${getWhatsappNumber()}`}
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="bg-white/10 hover:bg-white/20 w-10 h-10 rounded-full flex items-center justify-center transition duration-300"

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -67,3 +67,10 @@ afterEach(() => {
 afterAll(() => {
   vi.useRealTimers();
 });
+
+// Mock ResizeObserver
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
This PR updates the Contact Section to use the Sanity CMS (`siteSettings`) as the single source of truth for contact information (address, phone, email, hours), eliminating duplication with the Footer. It includes logic to handle dynamic data fetching with fallbacks, a dynamic WhatsApp link generator, unit tests, and documentation for content editors.

---
*PR created automatically by Jules for task [2360040160462861498](https://jules.google.com/task/2360040160462861498) started by @govinda777*