### PR TITLE
Fix Anchor Navigation and F5 Refresh Errors

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,34 +12,27 @@ import { useState, useEffect } from "react";
 
 // Hook personalizado para lidar com o base path
 const useBasePath = (): [string, (to: string) => void] => {
-  const [base, setBase] = useState("");
-  const [location, setLocation] = useState("");
+  const getInitialPath = () => {
+    const basePath = import.meta.env.VITE_BASE_PATH || import.meta.env.BASE_URL || "/";
+    let path = window.location.pathname;
+
+    if (basePath !== "/" && path.startsWith(basePath)) {
+      path = path.replace(basePath, "");
+    }
+
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+
+    return path;
+  };
+
+  const [base] = useState(() => import.meta.env.VITE_BASE_PATH || import.meta.env.BASE_URL || "/");
+  const [location, setLocation] = useState(getInitialPath);
 
   useEffect(() => {
-    // Obtém o base path do Vite em produção
-    const basePath = import.meta.env.VITE_BASE_PATH || import.meta.env.BASE_URL;
-    setBase(basePath);
-
-    // Atualiza a localização inicial
-    let path = window.location.pathname;
-    if (basePath !== "/" && path.startsWith(basePath)) {
-        path = path.replace(basePath, "");
-    }
-    if (!path.startsWith("/")) {
-        path = "/" + path;
-    }
-    setLocation(path);
-
-    // Listener para mudanças na URL
     const handleLocationChange = () => {
-      let newPath = window.location.pathname;
-      if (basePath !== "/" && newPath.startsWith(basePath)) {
-        newPath = newPath.replace(basePath, "");
-      }
-      if (!newPath.startsWith("/")) {
-        newPath = "/" + newPath;
-      }
-      setLocation(newPath);
+      setLocation(getInitialPath());
     };
 
     window.addEventListener("popstate", handleLocationChange);
@@ -47,12 +40,30 @@ const useBasePath = (): [string, (to: string) => void] => {
   }, []);
 
   const navigate = (to: string) => {
-    const cleanBase = base.endsWith('/') ? base.slice(0, -1) : base;
-    const cleanTo = to.startsWith('/') ? to : '/' + to;
-    const newPath = cleanBase + (to === "/" ? "" : cleanTo);
+    // Se for apenas uma âncora e não estivermos na home, vai para a home com a âncora
+    if (to.startsWith('#') && location !== '/') {
+      to = '/' + to;
+    }
 
-    window.history.pushState(null, "", newPath);
-    setLocation(to);
+    const [pathWithoutHash, hash] = to.split('#');
+
+    const cleanBase = base.endsWith('/') ? base.slice(0, -1) : base;
+
+    // Se pathWithoutHash for vazio, mantém o location atual
+    const targetPath = pathWithoutHash === "" ? location : (pathWithoutHash.startsWith('/') ? pathWithoutHash : '/' + pathWithoutHash);
+
+    const fullUrl = cleanBase + (targetPath === "/" ? "" : targetPath) + (hash ? '#' + hash : '');
+
+    window.history.pushState(null, "", fullUrl);
+    setLocation(targetPath);
+
+    // Sempre dispara hashchange se houver hash, para garantir o scroll
+    if (hash) {
+      // Pequeno delay para garantir que a navegação de página (se houver) já ocorreu
+      setTimeout(() => {
+        window.dispatchEvent(new HashChangeEvent("hashchange"));
+      }, 100);
+    }
   };
 
   return [location, navigate];

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -32,7 +32,7 @@ const Header = () => {
       dropdown: true,
       items: programs?.map(p => ({
         name: p.title,
-        path: `/programas/${p.slug?.current}`
+        path: `#${p.slug?.current}`
       })) || []
     },
     { name: "Sobre", path: "#sobre" },
@@ -116,7 +116,10 @@ const Header = () => {
               item.dropdown ? (
                 <DropdownMenu key={item.name}>
                   <DropdownMenuTrigger asChild>
-                    <button className="nav-link flex items-center">
+                    <button
+                      onClick={() => navigate(item.path)}
+                      className="nav-link flex items-center"
+                    >
                       {item.name}
                       <ChevronDown className="h-4 w-4 ml-1" />
                     </button>

--- a/client/src/hooks/use-navigation.ts
+++ b/client/src/hooks/use-navigation.ts
@@ -12,20 +12,8 @@ export const useNavigation = () => {
   }, []);
 
   const navigate = useCallback((to: string) => {
-    // Se for um link de âncora
-    if (to.startsWith('#')) {
-      // Se já estivermos na home, apenas atualiza o hash
-      if (location === '/' || location === '') {
-        window.location.hash = to;
-      } else {
-        // Se estivermos em outra página, navega para a home com o hash
-        setLocation('/' + to);
-      }
-      return;
-    }
-
     setLocation(to);
-  }, [location, setLocation]);
+  }, [setLocation]);
 
   return {
     currentPath: location,


### PR DESCRIPTION
This PR fixes the navigation issues where anchor links (hashes) were not triggering the expected scroll behavior and page refreshes (F5) were resulting in "404 Not Found" errors.

Key changes:
1. **App.tsx**: The `useBasePath` hook now calculates the initial route synchronously from `window.location.pathname`. This ensures the router has the correct context immediately upon page load, fixing the refresh bug. The `navigate` function was also updated to manually dispatch a `HashChangeEvent` when a hash is present, ensuring that components listening for hash changes (like the smooth-scroll logic) are correctly triggered.
2. **use-navigation.ts**: Simplified the hook to delegate all routing logic to the centralized `setLocation` function in `App.tsx`.
3. **Header.tsx**: Updated the 'Programas' navigation to use anchors (`#:slug`) instead of navigating to detail pages by default, as requested for the landing page experience.
4. **Clean up**: Removed `dev_server.log`.

---
*PR created automatically by Jules for task [7641882756905963952](https://jules.google.com/task/7641882756905963952) started by @govinda777*