### PR TITLE
Update establishment year to 2018

### DIFF
--- a/client/src/components/sections/HeroSection.tsx
+++ b/client/src/components/sections/HeroSection.tsx
@@ -151,7 +151,7 @@ export default function HeroSection(){
                     ))
                   ) : (
                     <>
-                      Em <span className="text-[var(--azul)]">Sorocaba</span> desde 2008, somos um centro de boulder e cross training que trata cada via como um <span className="font-serif-it italic" style={{fontFamily:'Fraunces',fontStyle:'italic',fontWeight:300}}>problema</span> a ser lido com o corpo.
+                      Em <span className="text-[var(--azul)]">Sorocaba</span> desde 2018, somos um centro de boulder e cross training que trata cada via como um <span className="font-serif-it italic" style={{fontFamily:'Fraunces',fontStyle:'italic',fontWeight:300}}>problema</span> a ser lido com o corpo.
                     </>
                   )}
                 </p>

--- a/sanity/studio/schemas/heroSection.ts
+++ b/sanity/studio/schemas/heroSection.ts
@@ -21,7 +21,7 @@ export default {
       name: 'subtitle',
       title: 'Subtítulo / Descrição',
       type: 'text',
-      initialValue: 'Em Sorocaba desde 2008, somos um centro de boulder e cross training que trata cada via como um problema a ser lido com o corpo.'
+      initialValue: 'Em Sorocaba desde 2018, somos um centro de boulder e cross training que trata cada via como um problema a ser lido com o corpo.'
     },
     {
       name: 'backgroundImage',


### PR DESCRIPTION
This PR updates the gym's establishment year from 2008 to 2018 across the codebase.

Key changes:
1.  **Frontend:** Modified `client/src/components/sections/HeroSection.tsx` to update the fallback subtitle text.
2.  **CMS Schema:** Updated `sanity/studio/schemas/heroSection.ts` to set the default value for the subtitle field to "2018".

Verification:
- Ran `vitest` on `HeroSection.test.tsx` (Passed).
- Performed visual verification using Playwright, confirming the year displays correctly as "2018" in the Hero section.
- Verified that both the fallback UI and the CMS schema are synchronized.

---
*PR created automatically by Jules for task [134396081046370490](https://jules.google.com/task/134396081046370490) started by @govinda777*